### PR TITLE
Bump faiss version to 1.4 and sync versioning number

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ are implemented on the GPU. It is developed by Facebook AI Research.
 """
 setup(
     name='faiss_prebuilt',
-    version='0.1.3.1',
+    version='1.4',
     description='A library for efficient similarity search and clustering of dense vectors',
     long_description=long_description,
     url='https://github.com/facebookresearch/faiss',


### PR DESCRIPTION
Hey @orf, 

-update the git submodule used for the build to the latest released version of the faiss liblary (1.4)
- set the version of the faiss_prebuilt library the same as the library version

Not sure about your opinion regarding versioning I thought it might be clearer if _prebuilt package follows library versioning. 
